### PR TITLE
SNSシェア用文字列のイベント名を修正

### DIFF
--- a/frontend/assets/tmpl/common/_header.pug
+++ b/frontend/assets/tmpl/common/_header.pug
@@ -5,10 +5,10 @@
             img(src="./assets/images/title_header.svg" alt="php conference Kansai 2017")
     .header_share
         ul
-            li: a(href="https://twitter.com/intent/tweet?text=関西最大のPHPイベントは7月15日(土)開催！ カンファレンス関西2017 https://2017.kphpug.jp&hashtags=phpkansai" target="_blank")
+            li: a(href="https://twitter.com/intent/tweet?text=関西最大のPHPイベントは7月15日(土)開催！ PHPカンファレンス関西2017 https://2017.kphpug.jp&hashtags=phpkansai" target="_blank")
                 i.fa.fa-twitter
                 | tweet
-            li: a(href="https://www.facebook.com/sharer.php?u=https://2017.kphpug.jp&amp;t=関西最大のPHPイベントは7月15日(土)開催！ カンファレンス関西2017&hashtags=phpkansai" target="_blank")
+            li: a(href="https://www.facebook.com/sharer.php?u=https://2017.kphpug.jp&amp;t=関西最大のPHPイベントは7月15日(土)開催！ PHPカンファレンス関西2017&hashtags=phpkansai" target="_blank")
                 i.fa.fa-facebook
                 | share
     .header_join

--- a/frontend/assets/tmpl/topSection/_secSocial.pug
+++ b/frontend/assets/tmpl/topSection/_secSocial.pug
@@ -9,16 +9,16 @@
                 | シェアやリツイートにて応援をよろしくお願いします！
 
             .secShare_facebook
-                a(href="https://www.facebook.com/sharer.php?u=https://2017.kphpug.jp&amp;t=関西最大のPHPイベントは7月15日(土)開催！ カンファレンス関西2017&hashtags=phpkansai" target="_blank").secShare_facebookFollow
+                a(href="https://www.facebook.com/sharer.php?u=https://2017.kphpug.jp&amp;t=関西最大のPHPイベントは7月15日(土)開催！ PHPカンファレンス関西2017&hashtags=phpkansai" target="_blank").secShare_facebookFollow
                     i.fa.fa-facebook
                     p PHPカンファレンス関西
                     span @pcon.kansai　 #phpkansai
                 .secShare_facebookShare
-                    a(href="https://www.facebook.com/sharer.php?u=https://2017.kphpug.jp&amp;t=関西最大のPHPイベントは7月15日(土)開催！ カンファレンス関西2017&hashtags=phpkansai" target="_blank") Facebookでシェアする
+                    a(href="https://www.facebook.com/sharer.php?u=https://2017.kphpug.jp&amp;t=関西最大のPHPイベントは7月15日(土)開催！ PHPカンファレンス関西2017&hashtags=phpkansai" target="_blank") Facebookでシェアする
             .secShare_twitter
-                a(href="https://twitter.com/intent/tweet?text=関西最大のPHPイベントは7月15日(土)開催！ カンファレンス関西2017 https://2017.kphpug.jp&hashtags=phpkansai" target="_blank").secShare_twitterFollow
+                a(href="https://twitter.com/intent/tweet?text=関西最大のPHPイベントは7月15日(土)開催！ PHPカンファレンス関西2017 https://2017.kphpug.jp&hashtags=phpkansai" target="_blank").secShare_twitterFollow
                     i.fa.fa-twitter
                     p PHPカンファレンス関西
                     span @phpcon_kansai　 #phpkansai
                 .secShare_twitterShare
-                    a(href="https://twitter.com/intent/tweet?text=関西最大のPHPイベントは7月15日(土)開催！ カンファレンス関西2017 https://2017.kphpug.jp&hashtags=phpkansai" target="_blank") Twitterでシェアする
+                    a(href="https://twitter.com/intent/tweet?text=関西最大のPHPイベントは7月15日(土)開催！ PHPカンファレンス関西2017 https://2017.kphpug.jp&hashtags=phpkansai" target="_blank") Twitterでシェアする


### PR DESCRIPTION
`カンファレンス関西2017` → `PHPカンファレンス関西2017`